### PR TITLE
Moving 'Authorization' header configuration outside the 'forgeme' condition

### DIFF
--- a/background.js
+++ b/background.js
@@ -61,16 +61,15 @@ var requestFilter = {
                     value: jiraUrl
                 });
             }
-
-            if (togglApiToken.trim() !== '') {
-                var b64Authorization = togglApiToken + ':api_token';
-                headers.push({
-                    name: 'Authorization',
-                    value: 'Basic ' + btoa(b64Authorization)
-                });
-            }
         }
 
+        if (togglApiToken.trim() !== '') {
+            var b64Authorization = togglApiToken + ':api_token';
+            headers.push({
+                name: 'Authorization',
+                value: 'Basic ' + btoa(b64Authorization)
+            });
+        }
 
         blockingResponse.requestHeaders = headers;
         return blockingResponse;


### PR DESCRIPTION
For some reason the header loses the authorization setting and the 'forgeme' condition prevents this setting from being made again