### PR TITLE
Add ability to round duration before submitting

### DIFF
--- a/options.html
+++ b/options.html
@@ -15,6 +15,9 @@
         <label>Log Work comment sent with every log</label>
         <input id="log-comment" style="width: 100%;" />
         <br />
+        <br /><label>Round duration to next x minutes. (15 will round to to the next quater => 24 will become 30 etc.)</label>
+        <input id="round_minutes" style="width: 100%;" />
+        <br />
         <br />
         <label>Should merge Toggl Time by...?</label>
         <br />

--- a/options.js
+++ b/options.js
@@ -5,12 +5,14 @@ function saveOptions() {
     var mergeEntriesBy = document.getElementById('merge-entries-by').value;
     var togglApiToken = document.getElementById('toggl-api-token').value;
     var jumpToToday = document.getElementById('jump-to-today').checked;
+    var roundMinutes = document.getElementById('round_minutes').value;
     chrome.storage.sync.set({
         url: url,
         comment: comment,
         mergeEntriesBy: mergeEntriesBy,
         jumpToToday: jumpToToday,
         togglApiToken: togglApiToken,
+        roundMinutes:roundMinutes
     }, function () {
         // Update status to let user know options were saved.
         var status = document.getElementById('status');
@@ -31,12 +33,14 @@ function restoreOptions() {
         mergeEntriesBy: 'no-merge',
         jumpToToday: false,
         togglApiToken: '',
+        roundMinutes: 0,
     }, function (items) {
         document.getElementById('jira-url').value = items.url;
         document.getElementById('log-comment').value = items.comment;
         document.getElementById('merge-entries-by').value = items.mergeEntriesBy;
         document.getElementById('toggl-api-token').value = items.togglApiToken;
         document.getElementById('jump-to-today').checked = items.jumpToToday;
+        document.getElementById('round_minutes').checked = items.roundMinutes;
     });
 }
 

--- a/parser.js
+++ b/parser.js
@@ -197,7 +197,7 @@ function fetchEntries() {
         entries.forEach(function (entry) {
             entry.description = entry.description || 'no-description';
             var issue = entry.description.split(' ')[0];
-            var togglTime = entry.duration;
+            var togglTime = roundUp(entry.duration, config.roundUpMinutes);
 
             var dateString = toJiraWhateverDateTime(entry.start);
             var dateKey = createDateKey(entry.start);
@@ -233,6 +233,22 @@ function fetchEntries() {
 
         renderList();
     });
+}
+
+/**
+* Round duration up to next `minutes`.
+* No rounding will be applied if minutes is zero.
+* 
+* Example: round to next quater:
+*  roundUp(22, 15) = 30 // rounded to the next quarter
+*  roundUp(35, 60) = 60 // round to full hour
+*  roundUp(11, 0) = 11 // ignored rounding
+*/
+function roundUp(initialDuration, minutes) {
+    if (minutes == 0) return initialDuration
+    // make sure minium `minutes` are tracked
+    var roundedDuration = ((initialDuration % minutes) + 1) * minutes
+    return roundedDuration;
 }
 
 function toJiraWhateverDateTime(date) {


### PR DESCRIPTION
As I don't want to track exact numbers because sometimes I started the timer with delay, I added an option to round duration up to the next x minutes and added the corresponding option to the settings page.

Sorry, I did not test this as I'm not deep into chrome extensions, so please feeel free to modify.