### PR TITLE
Fix repeated logging without popup close

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -156,6 +156,7 @@ function submitEntries() {
             $.post(config.url + '/rest/api/latest/issue/' + log.issue + '/worklog', body,
                 function success(response) {
                     console.log('success', response);
+                    log.submit = false;
                     $('#result-' + log.id).text('OK').addClass('success').removeClass('info');
                     $('#input-' + log.id).removeAttr('checked').attr('disabled', 'disabled');
                     $("#comment-" + log.id).attr('disabled', 'disabled');


### PR DESCRIPTION
When issue is logged to Jira and "log to jira" button is pressed again without closing popup window, issue id logged repeatedly, even if checkbox is unchecked