### PR TITLE
Update toggl API url

### DIFF
--- a/identity.js
+++ b/identity.js
@@ -20,7 +20,7 @@ var identity = {
     ConnectToToggl: function (togglApiToken) {
         // https://github.com/toggl/toggl_api_docs/blob/master/chapters/users.md
         return $.get({
-            url: 'https://www.toggl.com/api/v8/me',
+            url: 'https://api.track.toggl.com/api/v8/me',
             headers: {
                 "Authorization": "Basic " + btoa(togglApiToken + ':api_token')
             }

--- a/parser.js
+++ b/parser.js
@@ -155,7 +155,7 @@ function fetchEntries() {
     // Toggl API call with token authorisation header
     // https://github.com/toggl/toggl_api_docs/blob/master/chapters/time_entries.md
     $.get({
-        url: 'https://www.toggl.com/api/v8/time_entries' + dateQuery,
+        url: 'https://api.track.toggl.com/api/v8/time_entries' + dateQuery,
         headers: {
             "Authorization": "Basic " + btoa(config.togglApiToken + ':api_token')
         }


### PR DESCRIPTION
`www.toggl.com` API url support will be dropped at the end of the month.
This MR updates the calls to use the new `api.track.toggl.com` url.