### PR TITLE
Upgrade Toggl API to v9

### DIFF
--- a/identity.js
+++ b/identity.js
@@ -20,14 +20,14 @@ var identity = {
     ConnectToToggl: function (togglApiToken) {
         // https://github.com/toggl/toggl_api_docs/blob/master/chapters/users.md
         return $.get({
-            url: 'https://api.track.toggl.com/api/v8/me',
+            url: 'https://api.track.toggl.com/api/v9/me',
             headers: {
                 "Authorization": "Basic " + btoa(togglApiToken + ':api_token')
             }
         }).then(function (togglResult) {
             return result = { // transform the result
-                togglUserName: togglResult.data.fullname,
-                togglEmailAddress: togglResult.data.email
+                togglUserName: togglResult.fullname,
+                togglEmailAddress: togglResult.email
             }
         });
     },

--- a/parser.js
+++ b/parser.js
@@ -155,7 +155,7 @@ function fetchEntries() {
     // Toggl API call with token authorisation header
     // https://github.com/toggl/toggl_api_docs/blob/master/chapters/time_entries.md
     $.get({
-        url: 'https://api.track.toggl.com/api/v8/time_entries' + dateQuery,
+        url: 'https://api.track.toggl.com/api/v9/me/time_entries' + dateQuery,
         headers: {
             "Authorization": "Basic " + btoa(config.togglApiToken + ':api_token')
         }
@@ -164,7 +164,6 @@ function fetchEntries() {
         logs = [];
         unloggableTogglEntries = 0;
 
-        entries.reverse();
         entries.forEach(function (entry) {
             entry.description = entry.description || 'no-description';
             var issue = entry.description.split(' ')[0];


### PR DESCRIPTION
Fixes https://github.com/fyyyyy/Toggl-to-Jira-Chrome-Extension/issues/30.

The most significant change is that the `time_entries` endpoint now returns the most recent entries first, so there's no need to reverse them anymore.

I didn't build the extension and test these changes as I use a corporate JIRA server and right now I'm on PTO so I don't have access to it. I did test the API endpoints with Postman and compared the responses between v8 and v9, so I'm pretty confident the changes will work. I would still appreciate if someone could test them though 🙂 